### PR TITLE
Fixed wrong variable name, fixed "Undefined $json variable" notice.

### DIFF
--- a/api/code/php/simple_api_server_test_harness.php
+++ b/api/code/php/simple_api_server_test_harness.php
@@ -93,13 +93,15 @@ function call_api_server($method, $endpoint, $data) {
         
     $path = $endpoint;
     // if present, concatenate encoded json to $endpoint for Signature:
-    if ($data != NULL) {
+    if ($data !== NULL) {
     	$json = json_encode($data);
         $path .= $json;
+    } else {
+        $json = NULL;
     }
 
     $authorization = "key=" . $key . ",timestamp=" . $time . ",nonce=" . $nonce;
-    $signature =  hash_hmac('sha256', $authorization . $path . $body, $secret);
+    $signature =  hash_hmac('sha256', $authorization . $path . $json, $secret);
     $headers = build_headers($authorization, $signature);
     
     print_debug_info($method, $endpoint, $headers);


### PR DESCRIPTION
Hey,

I'm trying to use provided code samples and I found&fixed a few errors, so here is the fix.

However, I am getting access denied errors from both `api.cloudtrax.com` and `api-v2.cloudtrax.com` when I'm trying to create a network with an admin API key/secret. Listing networks works fine, so the key probably isn't the issue. I'll open a support request for that I suppose.

Cheers!